### PR TITLE
Markdownページのタイポの修正

### DIFF
--- a/data/en/basic/markdown.mdx
+++ b/data/en/basic/markdown.mdx
@@ -25,7 +25,7 @@ import { markdownPlugin } from "@spearly/spear-markdown-plugin";\n
 export default {\n
   ...\n
   "plugins": [\n
-    markdowmarkdownPluginnPlugin(),\n
+    markdownPlugin(),\n
   ]\n
 }\n
 ```

--- a/data/jp/basic/markdown.mdx
+++ b/data/jp/basic/markdown.mdx
@@ -26,7 +26,7 @@ import { markdownPlugin } from "@spearly/spear-markdown-plugin";\n
 export default {\n
   ...\n
   "plugins": [\n
-    markdowmarkdownPluginnPlugin(),\n
+    markdownPlugin(),\n
   ]\n
 }\n
 ```


### PR DESCRIPTION
 ## issue
#7 

 ## 変更内容
 - ページに表示されているコードを修正するためにプログラムの一部を修正しました。

en/basic/markdown.mdx　２８行目
修正前　markdowmarkdownPluginnPlugin(),/n
修正後　markdownPlugin(),/n

jp/basic/markdown.mdx　２９行目
修正前　markdowmarkdownPluginnPlugin(),/n
修正後　markdownPlugin(),/n

 ## 変更後の期待される出力結果
 - 修正したコードがそのまま表示されます。
![image](https://github.com/unimal-jp/spear-doc/assets/146790540/eea72bfe-a9e8-4c2c-b72d-1e1233cd45e7)
