### PR TITLE
画面別にコンテンツを広げました#16

### DIFF
--- a/src/assets/css/main.scss
+++ b/src/assets/css/main.scss
@@ -18,7 +18,7 @@ section.main {
     margin: auto auto;
     max-width: calc(80% - 50px);
     div {
-        width: 500px;
+        width: 900px;
         margin: auto;
 
         p {
@@ -39,7 +39,7 @@ section.main {
         }
 
         ul {
-            width: 500px;
+            width: 900px;
             text-align: left;
             margin: auto;
         }
@@ -49,7 +49,7 @@ section.main {
         }
 
         pre {
-            width: 500px; 
+            width: 900px; 
             margin: auto;
             border: 1px solid #B0B0B0;
             border-radius: 4px;
@@ -63,7 +63,7 @@ section.main {
         }
 
         table {
-            width: 500px;
+            width: 900px;
             margin: auto;
             border-collapse: collapse;
             border: 1px solid #B0B0B0;


### PR DESCRIPTION
lssue
#16 

内容
PC で開いてもコンテンツの幅が 500px になっていたため、コンテンツの幅を900pxに変更しました。
21行目　width: 500px;
               width: 900px;
42行目　width: 500px;
               width: 900px;
52行目　width: 500px;
               width: 900px;
66行目　width: 500px;
               width: 900px;

<img width="1079" alt="スクリーンショット 2023-12-05 113502" src="https://github.com/unimal-jp/spear-doc/assets/146790531/eaceb85b-557d-4edb-ad53-436ad3131572">
