### PR TITLE
貢献者の欄に自分のアカウントを追加

### DIFF
--- a/data/jp/top/top-announce.mdx
+++ b/data/jp/top/top-announce.mdx
@@ -62,5 +62,6 @@ Spear のドキュメントを提供しています。以下のページまた�
   <tr>
     <td align="center"><a href="https://github.com/pandaulait"><img src="https://github.com/pandaulait.png" width="100px;" alt=""/><br /><sub><b>pandaulait</b></sub></a><br /><a href="https://github.com/unimal-jp/spear/issues?q=author%3Apandaulait" title="Bug reports">🐛</a>  <a href="#ideas-shirakaba" title="Ideas, Planning, & Feedback">🤔</a></td>
     <td align="center"><a href="https://github.com/oxo-yuta"><img src="https://github.com/oxo-yuta.png" width="100px;" alt=""/><br /><sub><b>oxo-yuta</b></sub></a><br /><a href="https://github.com/unimal-jp/spear/issues?q=author%3Aoxo-yuta" title="Bug reports">🐛</a> <a href="#ideas-shirakaba" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://github.com/June202325"><img src="https://github.com/June202325.png" width="100px;" alt=""/><br /><sub><b>June</b></sub></a><br /><a href="https://github.com/unimal-jp/spear/issues?q=author%3June202325" title="Code">💻</a>
   </tr>
 </table>


### PR DESCRIPTION
<h1>Issue</h1>
#29
<h1>変更目的</h1>
このページの修正に携わったことを周知してもらうため。
<h1>変更内容</h1>
自分のアカウント情報を追加。
<h1>確認手順</h1>

- [ ] 貢献者欄にJuneのアカウントが表示される。

<h1>結果</h1>

![スクリーンショット 2023-12-05 123210](https://github.com/unimal-jp/spear-doc/assets/147455473/907f4341-fbb0-4453-a5ff-2863fef4a61c)
