### PR TITLE
貢献者に自分の名前を追加

### DIFF
--- a/data/en/top/top-announce.mdx
+++ b/data/en/top/top-announce.mdx
@@ -63,5 +63,6 @@ This is our contributors! Many thanks for their contribution!
   <tr>
     <td align="center"><a href="https://github.com/pandaulait"><img src="https://github.com/pandaulait.png" width="100px;" alt=""/><br /><sub><b>pandaulait</b></sub></a><br /><a href="https://github.com/unimal-jp/spear/issues?q=author%3Apandaulait" title="Bug reports">🐛</a>  <a href="#ideas-shirakaba" title="Ideas, Planning, & Feedback">🤔</a></td>
     <td align="center"><a href="https://github.com/oxo-yuta"><img src="https://github.com/oxo-yuta.png" width="100px;" alt=""/><br /><sub><b>oxo-yuta</b></sub></a><br /><a href="https://github.com/unimal-jp/spear/issues?q=author%3Aoxo-yuta" title="Bug reports">🐛</a> <a href="#ideas-shirakaba" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://github.com/K-Yuma"><img src="https://github.com/K-Yuma.png" width="100px;" alt=""/><br /><sub><b>K-Yuma</b></sub></a><br /><a href="https://github.com/unimal-jp/spear/commits?author=K-Yuma" title="Code">💻</a></td>
   </tr>
 </table>

--- a/data/jp/top/top-announce.mdx
+++ b/data/jp/top/top-announce.mdx
@@ -62,5 +62,6 @@ Spear のドキュメントを提供しています。以下のページまた�
   <tr>
     <td align="center"><a href="https://github.com/pandaulait"><img src="https://github.com/pandaulait.png" width="100px;" alt=""/><br /><sub><b>pandaulait</b></sub></a><br /><a href="https://github.com/unimal-jp/spear/issues?q=author%3Apandaulait" title="Bug reports">🐛</a>  <a href="#ideas-shirakaba" title="Ideas, Planning, & Feedback">🤔</a></td>
     <td align="center"><a href="https://github.com/oxo-yuta"><img src="https://github.com/oxo-yuta.png" width="100px;" alt=""/><br /><sub><b>oxo-yuta</b></sub></a><br /><a href="https://github.com/unimal-jp/spear/issues?q=author%3Aoxo-yuta" title="Bug reports">🐛</a> <a href="#ideas-shirakaba" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://github.com/K-Yuma"><img src="https://github.com/K-Yuma.png" width="100px;" alt=""/><br /><sub><b>K-Yuma</b></sub></a><br /><a href="https://github.com/unimal-jp/spear/commits?author=K-Yuma" title="Code">💻</a></td>
   </tr>
 </table>


### PR DESCRIPTION
 ## issue
#23
 ## 修正内容
- /data/en/top/top-announce.mdxの６５行目と６６行目の間に以下のコードを追加しました。
![スクリーンショット 2023-12-12 094056](https://github.com/unimal-jp/spear-doc/assets/146790540/c159b968-a069-4f78-bb91-d5650e3232bc)
- /data/jp/top/top-announce.mdxの６４行目と６５行目の間に以下のコードを追加しました。
![スクリーンショット 2023-12-12 094056](https://github.com/unimal-jp/spear-doc/assets/146790540/ea6c96d5-a29f-406b-b9af-6b944acc1a8b)
 ##  期待される出力結果
 - 貢献者欄にK-Yumaの名前と画像が表示される