### PR TITLE
Fix some header styles

### DIFF
--- a/src/assets/css/header.scss
+++ b/src/assets/css/header.scss
@@ -4,7 +4,7 @@ header.header {
     left: 0;
     height: 80px;
     background-color: #d8dafa;
-    padding-top: 80px;
+    z-index: 10;
 
     > nav {
         width: 100vw;

--- a/src/assets/css/main.scss
+++ b/src/assets/css/main.scss
@@ -3,7 +3,7 @@
 header.top {
     display: block;
     text-align: center;
-    padding-top: 2rem;
+    padding-top: 72px;
     .spear-description {
         font-size: 1.8rem;
     }


### PR DESCRIPTION
The logo on the top page was hidden and this has been modified to be visible.

Before
<img width="1439" alt="Screenshot 2024-04-27 at 12 53 51 PM" src="https://github.com/unimal-jp/spear-doc/assets/60183777/2fb11566-6653-42ee-a71f-ec89ef0f298b">

After
<img width="1440" alt="Screenshot 2024-04-27 at 1 10 46 PM" src="https://github.com/unimal-jp/spear-doc/assets/60183777/3f11410a-8544-4aef-89bd-b41248d6e25d">

Also, a snippet of code seemed to be coming above the header, so a z-index was added to the header so that the header is at the top.

Before
<img width="1440" alt="Screenshot 2024-04-27 at 12 54 05 PM" src="https://github.com/unimal-jp/spear-doc/assets/60183777/64f28800-f327-4c9b-9198-df6b9d893aac">

After
<img width="1440" alt="Screenshot 2024-04-27 at 1 10 56 PM" src="https://github.com/unimal-jp/spear-doc/assets/60183777/b2a672f6-ebb4-4c1e-8474-51c93a1c155a">
